### PR TITLE
OTAA Join Accept Message Decoding (Issue Help)

### DIFF
--- a/dragino/LoRaWAN/MHDR.py
+++ b/dragino/LoRaWAN/MHDR.py
@@ -21,7 +21,7 @@ class MHDR:
         self.mhdr = mhdr
         mversion = mhdr & self.MHDR_MAJOR
         if mversion != self.LORAWAN_V1:
-            raise MalformedPacketException("Invalid major version %d", mversion)
+            raise MalformedPacketException("Invalid major version %d"%(mversion))
 
     def to_raw(self):
         return self.mhdr


### PR DESCRIPTION
Hi,

Pull Request:
- a small fix to the MHDR MalformedPacketException message string

Issue (Since there was no issue tab for this repo, I decided to post it here.):

I am using a end node device build using Dragino LoRa/GPS HAT + RPi 3 b+, I had successfully connected to a test RPi single channel gateway using ABP, and both the end device and gateway are on The Things Network.

Now, I am trying to connect my end node device to:

- Platform: The Actility ThingPark Platform, The ThingPark Platform only supports OTAA activation. 
- Gateway: Cisco Wireless Gateway for LoRaWAN.

Since the device doesn't come with a DevEUI, AppEui and AppKey, I generated random DevEUI, AppEui and AppKey in The Things Network, and copied them in the dragino.ini.default config file using the OTAA mode. I copied the same keys, and added the end device to the Actility ThingPark Platform.

When I run the test.py hello world example, after the **node sends the join request, the join request shows up in the Actility ThingPark Platform, and I can see the server sends a join accept message to the node. However, the node keeps giving error when decoding the join accpet message**, and it never got to the point where it is registered (i.e it having the DevAddr).

Have anyone had success with the OTAA connection? Thanks in advance for sharing and helping!

Error Message Log in the next comment.